### PR TITLE
Fix bug affecting the data retrieved for a given week

### DIFF
--- a/src/Controller/WarsController.php
+++ b/src/Controller/WarsController.php
@@ -53,7 +53,7 @@ class WarsController extends AppController
         $week = $this->request->query('week') ? $this->request->query('week') : date('W');
 
         $dto = new Time();
-        $this->battle_start = $dto->setISODate($year, $week)->modify('-1 days')->format('Y-m-d');
+        $this->battle_start = $dto->setISODate($year, $week)->format('Y-m-d');
         $this->battle_end = $dto->modify('+7 days')->format('Y-m-d');
 
         $contain = ['Guild', 'GuildOpp', 'Fights' => function ($q) {


### PR DESCRIPTION
The calculation of battle_start was pulling in data for the previous week, as not all wars end on Saturday (technically Sunday morning).
This also threw off battle_end since it was created using the modified battle_start